### PR TITLE
incusd/auth/oidc/oidc: Add oidc.redirect_uri setting to allow custom redirect URIs

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -231,7 +231,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	// Get the authentication methods.
 	authMethods := []string{api.AuthenticationMethodTLS}
 
-	oidcIssuer, oidcClientID, _, _, _ := s.GlobalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, _, _, _, _ := s.GlobalConfig.OIDCServer()
 	if oidcIssuer != "" && oidcClientID != "" {
 		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}
@@ -838,7 +838,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		case "network.ovn.northbound_connection", "network.ovn.ca_cert", "network.ovn.client_cert", "network.ovn.client_key":
 			ovnChanged = true
 
-		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.claim":
+		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.claim", "oidc.redirect_uri":
 			oidcChanged = true
 
 		case "openfga.api.url", "openfga.api.token", "openfga.store.id":
@@ -971,13 +971,13 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		}
 	}
 	if oidcChanged {
-		oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim := clusterConfig.OIDCServer()
+		oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim, oidcRedirectURI := clusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil
 		} else {
 			var err error
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim)
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim, oidcRedirectURI)
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2838,3 +2838,7 @@ on schedule.
 This adds tracking of CPU address sizes in the resources API.
 The main use of this is within clusters to calculate a cluster-wide
 maximum memory amount for hotplugging into virtual machines.
+
+## `oidc_redirect_uri`
+
+This introduces a new `oidc.redirect_uri` server configuration key which can be used to specify the OpenID Connect redirect URI. If not set, it assumes https://<host>/oidc/callback.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -5021,6 +5021,13 @@ This value is required by some providers.
 
 ```
 
+```{config:option} oidc.redirect_uri server-oidc
+:scope: "global"
+:shortdesc: "OpenID redirect URI, defaults to https://<host>/oidc/callback"
+:type: "string"
+
+```
+
 <!-- config group server-oidc end -->
 <!-- config group server-openfga start -->
 ```{config:option} openfga.api.token server-openfga

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -956,6 +956,14 @@ var ConfigSchema = config.Schema{
 	//  shortdesc: OpenID Connect claim to use as the username
 	"oidc.claim": {},
 
+	// gendoc:generate(entity=server, group=oidc, key=oidc.redirect_uri)
+	//
+	// ---
+	//  type: string
+	//  scope: global
+	//  shortdesc: OpenID redirect URI, defaults to https://<host>/oidc/callback
+	"oidc.redirect_uri": {},
+
 	// OVN networking global keys.
 
 	// gendoc:generate(entity=server, group=miscellaneous, key=network.ovn.integration_bridge)

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -5685,6 +5685,14 @@
 							"shortdesc": "Comma separated list of OpenID Connect scopes",
 							"type": "string"
 						}
+					},
+					{
+						"oidc.redirect_uri": {
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "OpenID redirect URI, defaults to https://<host>/oidc/callback",
+							"type": "string"
+						}
 					}
 				]
 			},


### PR DESCRIPTION
Helpful, if you try to run incus behind NAT but your IDP is online hosted.

Signed-off-by: Tim Beermann <tibeer@berryit.de>
